### PR TITLE
set_timeout must update timeout in watchdog_device

### DIFF
--- a/alim6117_wdt.c
+++ b/alim6117_wdt.c
@@ -179,6 +179,7 @@ static void ali_wdt_ping(void)
 
 static void ali_wdt_start(unsigned int wdt_timeout)
 {
+        /* printk(KERN_INFO "ALi M6117 calling alim6117_set_timeout with %u \n", wdt_timeout); */
 	alim6117_ulock_conf_register();
 	alim6117_wdt_disable();
 	alim6117_set_timeout(wdt_timeout);
@@ -250,8 +251,8 @@ static int ali_m6117_wdt_ping(struct watchdog_device *wdog)
 static int ali_m6117_wdt_set_timeout(struct watchdog_device *wdog,
 				unsigned int wdt_timeout)
 {
+        wdog->timeout = wdt_timeout;
 	ali_wdt_start(wdt_timeout);
-
 	return 0;
 }
 


### PR DESCRIPTION
the driver wasn't storing the new timeout value in the timeout field of struct watchdog_device,
causing userspace programs to assume the wrong value for timeout was used (watchdog_device.timeout
still contained the default timeout value) when using
   ioctl(fd, WDIOC_SETTIMEOUT, &timeout);
which updates the caller's timeout variable.

This caused the hardware WDT to reset the system if the new set_timeout value is less than the driver's default.